### PR TITLE
Feature/dependency and platform updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x
+
+composer self-update
+composer clear-cache
+composer update
+
+if [ "$DEPENDENCIES" = 'low' ] ; then
+    composer update --prefer-lowest --prefer-stable
+fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: php
+
+php:
+  - 7.1
+  - 7.2
+  - 7.3
+  - nightly
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+env:
+  matrix:
+    - DEPENDENCIES="high"
+    - DEPENDENCIES="low"
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+before_script:
+  - composer selfupdate
+  - sh .travis.install.sh
+
+script:
+  - bin/phpspec run --format=pretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ before_script:
   - sh .travis.install.sh
 
 script:
-  - bin/phpspec run --format=pretty
+  - vendor/bin/phpspec run --format=pretty

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ResolveEntityBundle
 ===================
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/vivait/ResolveEntityBundle/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/vivait/ResolveEntityBundle/?branch=master)
+[![Build Status](https://travis-ci.org/vivait/ResolveEntityBundle.svg?branch=master)](https://travis-ci.org/vivait/ResolveEntityBundle)
 
 Extends Symfony's entity manager form type to handle Doctrine's resolved entities

--- a/Vivait/ResolveEntityBundle/Form/Extension/ResolveEntityTypeExtension.php
+++ b/Vivait/ResolveEntityBundle/Form/Extension/ResolveEntityTypeExtension.php
@@ -5,7 +5,7 @@ namespace Vivait\ResolveEntityBundle\Form\Extension;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Vivait\ResolveEntityBundle\Service\EntityMapService;
 
 class ResolveEntityTypeExtension extends AbstractTypeExtension {
@@ -24,7 +24,7 @@ class ResolveEntityTypeExtension extends AbstractTypeExtension {
 		$this->entity_map = $entity_map;
 	}
 
-	public function setDefaultOptions(OptionsResolverInterface $resolver) {
+	public function setDefaultOptions(OptionsResolver $resolver) {
 		$entity_map = $this->entity_map;
 		$registry   = $this->registry;
 
@@ -38,9 +38,7 @@ class ResolveEntityTypeExtension extends AbstractTypeExtension {
 			return $entity_map->get($class, $class);
 		};
 
-		$resolver->setNormalizers(array(
-			'class' => $classNormalizer
-		));
+		$resolver->setNormalizer('class', $classNormalizer);
 	}
 
 	/**

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,16 @@
 		}
 	],
 	"minimum-stability": "dev",
-        "prefer-stable": true,
+	"prefer-stable": true,
 	"require": {
-		"php": ">=5.3",
-		"symfony/framework-bundle": "~2.1",
-		"symfony/form": "~2.1",
-		"doctrine/common": ">=2.2"
+		"php": ">=7.1",
+		"doctrine/common": ">=2.2",
+		"symfony/framework-bundle": "^3.4",
+		"symfony/form": "^3.4"
 	},
 	"require-dev": {
-		"sensio/framework-extra-bundle": ">=2.1",
-		"phpspec/phpspec": "~2.0"
+		"sensio/framework-extra-bundle": "^5.2",
+		"phpspec/phpspec": "^5.1"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
 	},
 	"require-dev": {
 		"sensio/framework-extra-bundle": "^5.2",
+		"sebastian/comparator": "^1.2.4",
 		"phpspec/phpspec": "^5.1"
 	},
 	"autoload": {

--- a/spec/Vivait/ResolveEntityBundle/Form/Extension/ResolveEntityTypeExtensionSpec.php
+++ b/spec/Vivait/ResolveEntityBundle/Form/Extension/ResolveEntityTypeExtensionSpec.php
@@ -5,7 +5,7 @@ namespace spec\Vivait\ResolveEntityBundle\Form\Extension;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Vivait\ResolveEntityBundle\Form\Extension\ResolveEntityTypeExtension;
 use Vivait\ResolveEntityBundle\Service\EntityMapService;
 
@@ -27,8 +27,8 @@ class ResolveEntityTypeExtensionSpec extends ObjectBehavior {
 			->shouldReturn('entity');
 	}
 
-	function it_should_register_a_custom_normalizer(OptionsResolverInterface $resolver) {
-		$resolver->setNormalizers(Argument::any())
+	function it_should_register_a_custom_normalizer(OptionsResolver $resolver) {
+		$resolver->setNormalizer('class', Argument::any())
 			->shouldBeCalled();
 
 		$this->setDefaultOptions($resolver);


### PR DESCRIPTION
Will need to be a new major version, as I've had to cater for the new 3.4 `OptionsResolver::setNormalizer` method signature (over the old `OptionsResolverInterface::setNormalizers`